### PR TITLE
add build dep on ros_environment to ensure the env variable ROS_VERSION is defined

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,8 @@
   <author email="sniekum@cs.utexas.edu">Scott Niekum</author>
   <author email="jwhitley@autonomoustuff.com">Joshua Whitley</author>
 
+  <buildtool_depend>ros_environment</buildtool_depend>
+
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 


### PR DESCRIPTION
Once this is merged I hope that the devel job will pass (together with ros-infrastructure/ros_buildfarm#621),